### PR TITLE
Reference source before libs when building

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #/bin/bash
 
-gcc `pkg-config gtk+-3.0 --cflags` `pkg-config --libs gtk+-3.0` -std=c99 -shared -O2 -g -fPIC -DDEBUG=1 -o ddb_misc_libbrowser_GTK3.so libbrowser.c utils.c support.c client.c $(pwd)/../musiclib-grpc/cgo/build/client.so
+gcc `pkg-config gtk+-3.0 --cflags` libbrowser.c utils.c support.c client.c -std=c99 -shared -O2 -g -fPIC -DDEBUG=1 -o ddb_misc_libbrowser_GTK3.so $(pwd)/../musiclib-grpc/cgo/build/client.so `pkg-config --libs gtk+-3.0`
 
 mkdir -p ~/.local/lib/deadbeef/
 cp ddb_misc_libbrowser_GTK3.so ~/.local/lib/deadbeef/ddb_misc_libbrowser_GTK3.so


### PR DESCRIPTION
Fixes gtk symbol errors at runtime on newer Ubuntu/gcc versions.

Source: https://stackoverflow.com/a/11547009/1760514

Fixes: https://github.com/mctofu/deadbeef-library/issues/4